### PR TITLE
[746] fix github action permissions issue on v5

### DIFF
--- a/.github/workflows/sync_peloton_to_garmin.yml
+++ b/.github/workflows/sync_peloton_to_garmin.yml
@@ -15,17 +15,17 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+env:
+  OUTPUT_DIR: /app/output
+
 jobs:
   sync:
     name: 🔄 Sync
     runs-on: ubuntu-latest
-    # The type of runner that the job will run on
     container: 
       image:  philosowaffle/peloton-to-garmin:console-stable
+      options: --user root
     steps:
-
-    - name: ⚙ Configure output directory
-      run: echo "OUTPUT_DIR=/app/output" >> $GITHUB_ENV
 
     - name: 📁Create output directory
       run: mkdir -p ${{ env.OUTPUT_DIR }}
@@ -86,18 +86,10 @@ jobs:
         P2G_GARMIN__PASSWORD: ${{ secrets.P2G_GARMIN__PASSWORD }}
         TZ: America/Chicago
 
-    - name: 💾 Save to output directory
-      # saveLocalCopy can be set when workflow action is manually run otherwise it's always skipped 
-      if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
-      run: |
-        apt-get update
-        apt-get install -y zip
-        zip -r -j output.zip ${{ env.OUTPUT_DIR }}
-        
     - name: ⤴ Upload output directory
       uses: actions/upload-artifact@v4
       if: ${{ github.event.inputs.saveLocalCopy == 'true' }}
       with:
         name: output
-        path: output.zip
+        path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: error

--- a/docker/Dockerfile.webui
+++ b/docker/Dockerfile.webui
@@ -1,7 +1,7 @@
 ###################
 # CREATE FINAL LAYER
 ###################
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 as final
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 
 RUN apt-get update \
 	&& apt-get -y install bash tzdata \
@@ -30,7 +30,7 @@ RUN dotnet tool install -g Microsoft.Web.LibraryManager.Cli \
 # BUILD WebUI
 ###################
 
-WORKDIR /build/src/WebUI
+WORKDIR /build/src/SharedUI
 RUN /root/.dotnet/tools/libman restore
 
 WORKDIR /build

--- a/mkdocs/docs/install/docker-webui.md
+++ b/mkdocs/docs/install/docker-webui.md
@@ -10,7 +10,7 @@ P2G provides a website user interface. Some key features include:
 
 ![P2G UI Demo](../img/p2g_demo.gif "P2G UI Demo")
 
-## docker-compose
+## ⬇️ Install
 
 *Pre-requisite:* You have either `docker-compose` or `Docker Desktop` installed
 
@@ -22,28 +22,57 @@ P2G provides a website user interface. Some key features include:
         1. Within the `webui` folder, also create a [configuration.local.json](https://github.com/philosowaffle/peloton-to-garmin/blob/master/docker/webui/config/webui/configuration.local.json) with slightly different content
         1. Your final directory structure should look similar to [this](https://github.com/philosowaffle/peloton-to-garmin/blob/master/docker/webui).
 1. Open a terminal in the `p2g-webui` folder
-1. Run: `docker-compose pull && docker-compose up -d`
+1. Run: `docker compose pull && docker compose up -d`
     1. This will pull the containers and start them up running in the background
     1. You can close the terminal at this time
 1. Open a browser and navigate to `http://localhost:8002`
 
 Any logs or generated files will be available in the `output` directory.  Additionally, you can learn more about customizing your configuration over in the [Configuration Section](../configuration/index.md)
 
+### Configuration
+
+You can learn more about customizing your configuration over in the [Configuration Section](../configuration/index.md).
+
+If you are migrating to the Web UI for the first time you will need to reconfigure most of your settings using the user interface.  The only settings that are carried over and still configured via the configuration file are the ones related to `Observability`.
+
 ### To stop P2G
 
 1. You can use Docker Desktop application to kill the containers
 1. Or, you can open a terminal in the `p2g-webui` folder
-    1. Run: `docker-compose down`
+    1. Run: `docker compose down`
 
-### To update P2G
-
-1. Open a terminal in the `p2g-webui` folder
-    1. Run: `docker-compose pull && docker-compose up -d`
-
-## Configuration
-
-If you are migrating to the Web UI for the first time you will need to reconfigure most of your settings using the user interface.  The only settings that are carried over and still configured via the configuration file are the ones related to `Observability`.
-
-## Open Api
+### Open Api
 
 To access the Open API spec  for P2G you will need to expose port `8080` on the Api docker container.  The open API spec will be available at `http://localhost:8001/swagger`.
+
+## ⬆️ Updating
+
+1. Open a terminal in the `p2g-webui` folder
+    1. Run: `docker compose pull && docker compose up -d`
+
+## ❌ Uninstalling
+
+1. You can use Docker Desktop application to kill the containers and delete the images
+1. Or, you can open a terminal in the `p2g-webui` folder
+    1. Run: `docker compose down && docker compose rm`
+1. Finally, delete the `p2g-webui` folder
+
+!!! warning
+    This is non-recoverable.  Any and all customizations will be lost.  You can re-install P2G again by starting over.
+
+## #️⃣ Changing Versions
+
+1. Find the image tags you want from the [releases page](https://github.com/philosowaffle/peloton-to-garmin/releases)
+1. Update the [docker-compose.yaml](https://github.com/philosowaffle/peloton-to-garmin/blob/master/docker/webui/docker-compose-ui.yaml) containers to reference those tags.
+1. Restart the containers
+    1. Run: `docker compose down && docker compose up -d`
+
+!!! warning
+
+    Attempting to use configuration or data from a later version of P2G with an older version is not guaranteed to work. You may need to reconfigure your instance.
+
+## 👪 Multiple Users
+
+To setup P2G for an additional user, simply download P2G run through the install process again in a new folder named `<PersonsName>-P2G`.  You will also need to update the `docker-compose.yaml` file to use unique names and ports for the containers.
+
+For this setup, tt is recommended to place P2G behind a reverse-proxy with authentication.  However, that is outside the scope of this documentation.

--- a/mkdocs/docs/install/github-action.md
+++ b/mkdocs/docs/install/github-action.md
@@ -18,12 +18,12 @@ The easiest way to use the action is to simply create a fork of the repo using t
 1. Create an account on [GitHub](https://github.com)
 1. Navigate to the [P2G repo](https://github.com/philosowaffle/peloton-to-garmin)
 1. In the upper right hand corner, click the button that says `Fork`
-1. Make note of the url to your forked copy
+1. Make note of or bookmark the url to your forked copy so that you’ll be able to easily find it again later when you’re ready to sync.
 1. Continue on to the [Secrets instructions](#secrets) below
 
 ### 2. Setup Secrets
 
-Once you've created your fork, you'll need to set a number of secrets in your repository.
+Once you've created your fork, you'll need to set a number of secrets in your repository.  Secrets are a tool for storing sensitive information our Action will need (like email and password) in a way that is private and not visible to others.
 
 1. From your forked copy of P2G, click the `Settings`
 1. Then, on the side nav, select `Secrets` and then `Actions`.
@@ -39,6 +39,8 @@ From this point on you can add secrets by clicking the `New repository secret` b
 | `P2G_GARMIN__PASSWORD`  | The password that you use to log into Garmin                         |
 
 #### Action Permissions
+
+In order for our newly created Action to run, we need to ensure it has the right permissions configured.
 
 1. From your forked copy of P2G, click the `Settings` tab
 1. Navigate to the settings for `Actions > General`
@@ -64,6 +66,7 @@ You can learn more about customizing your configuration over in the [Configurati
 
 1. Make a copy of your current configuration in `.github/workflows/sync_peloton_to_garmin.yml` as you will need to reapply these changes after updating.
 1. From the home page of your forked repository, there should be a button to `Sync fork`, click this to pull in the latest changes from the original repo.
+    1. If prompted always choose the latest new changes coming in over any customization you have done.  You can always re-apply your customization afterwards.
 1. Go back to your `.github/workflows/sync_peloton_to_garmin.yml` and re-apply any changes from step 1.
 
 ## ❌ Uninstalling

--- a/mkdocs/docs/migration/migrate-v4-v5.md
+++ b/mkdocs/docs/migration/migrate-v4-v5.md
@@ -9,7 +9,7 @@ First, identify your [install method](../install/index.md#-start-here-to-explore
 |:----------------|:------------------|:----------------|:-------------|:-------------|:------------|
 | [.NET 9](#net-9) | ✔️ | ❌ | ❌ | ❌ | ❌ |
 | [DeviceInfoPath replaced by DeviceInfoSettings](#deviceinfopath-replaced-by-deviceinfosettings) | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
-| [Fixed Non-Root Docker](#fixed-non-root-docker) | ❌ | ✔️ | ✔️ | ❌ | ❌ |
+| [Fixed Non-Root Docker](#fixed-non-root-docker) | ❌ | ✔️ | ✔️ | ✔️ | ❌ |
 
 ## Breaking Changes
 
@@ -38,3 +38,7 @@ If you encounter issues, start by trying the below steps:
 1. Ensure you have created a Group `p2g` with GroupId of `1015`, see [Docker User](../install/docker.md#docker-user)
 1. Ensure existing config and setting files are editable by the `p2g` Group
 1. Update your containers to run with `user: :p2g`. See [docker-compose.yaml](https://github.com/philosowaffle/peloton-to-garmin/blob/master/docker/webui/docker-compose-ui.yaml)
+
+#### GitHub Action Users
+
+If you use GitHub Actions for running P2G then the fix for this has already been applied to the latest version of the workflow file.  You can follow the normal [Updating steps](../install/github-action.md#️updating) to get the latest version.

--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -9,6 +9,6 @@
 		public const string WebUIName = "p2g_webui";
 		public const string ClientUIName = "p2g_clientui";
 
-		public const string AppVersion = "5.0.0";
+		public const string AppVersion = "5.0.1";
 	}
 }

--- a/vNextReleaseNotes.md
+++ b/vNextReleaseNotes.md
@@ -4,52 +4,25 @@
 > [!TIP]
 > You can find specific Upgrade Instructions by visitng the [Install Page](https://philosowaffle.github.io/peloton-to-garmin/latest/install/) for your particular flavor of P2G and looking for the section titled `⬆️ Updating`.
 
-## Breaking Changes
-
-> [!CAUTION]
-> Please see the [Migration Guide](https://philosowaffle.github.io/peloton-to-garmin/master/migration/migrate-v4-v5/) for specific instructions on how to address these breaking changes.
-
-- [#656] Uplift to .net 9
-- [#704] `DeviceInfoPath` fully removed and replaced by `DeviceInfoSettings`
-- [#473] Fix running rootless docker containers (@jpecora716)
-
-## New Features
-
-- [#556] Stacked Classes Support - P2G can now either automatically or on-demand combine Peloton workouts into a single final activity file that is uploaded to Garmin Connect
-- [#721] New Exercise Mappings added (@chloevoyer)
-- [#721] Honor reps when available on time based movements
-- [#724] Annual Challenge Page - Now shows current average minutes/day and minutes/week
-- [#740] Console/Docker Headless - Can now configure whether P2G should exit immediately or not on completion using `App.CloseConsoleOnFinish` (@DinoChiesa)
-- [#697] New API endpoint to sync last N workouts
-- [#487] Temporarily toggle logging verbosity from the UI for easier debugging and reporting
-
 ## Fixes
 
-- [#711] Friendlier error messages, especially on first start when nothing is configured yet
-- [#711] Fixed issue where Windows exe would somtimes fail to start on very first run, but would launch on second attempt
-- [#711] Prevent users from saving Passwords that use an unsupported character
-- [#732] Fixed some broken links on documentation site
-- [#577] Various improvements to the [Documentation Site](https://philosowaffle.github.io/peloton-to-garmin/latest/)
-
-## Housekeeping
-
-- [#672] Bump all dependencies
+- [#746] Fix permissions issue on v5 where the GitHub Action was failing to run
 
 ## Docker Tags
 
 - Console
     - `console-stable`
     - `console-latest`
-    - `console-v5.0.0`
+    - `console-v5.0.1`
     - `console-v5`
 
 - Api
     - `api-stable`
     - `api-latest`
-    - `api-v5.0.0`
+    - `api-v5.0.1`
     - `api-v5`
 - WebUI
     - `webui-stable`
     - `webui-latest`
-    - `webui-v5.0.0`
+    - `webui-v5.0.1`
     - `webui-v5`


### PR DESCRIPTION
* [746] Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* Update sync_peloton_to_garmin.yml

* [746] fix github action permissions issue on v5

* not sure why this is now failing